### PR TITLE
Add shell.nix file for nix development

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell rec {
+
+  shellHook=''
+  export PKG_CONFIG_PATH="${pkgs.glib.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+  export PKG_CONFIG_PATH="${pkgs.poppler_gi.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+  export PKG_CONFIG_PATH="${pkgs.SDL.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+  export PKG_CONFIG_PATH="${pkgs.cairo.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+  '';
+
+}


### PR DESCRIPTION
I'd like to use it and contribute, I added a `shell.nix` file for easy and simple nix development, one would have to change
`#include <SDL.h>` for `#include <SDL/SDL.h>` and these kind of things (which I think it should be done no matter what), but it should be fine.